### PR TITLE
fix(configuration): use ~/.asteroidpy for config and correct defaults…

### DIFF
--- a/asteroidpy/configuration.py
+++ b/asteroidpy/configuration.py
@@ -20,14 +20,12 @@ def save_config(config: ConfigParser) -> None:
     -------
 
     """
-    dir = user_config_dir("AsteroidPy")
-    if system() == "Windows":
-        separator = "\\"
-    else:
-        separator = "/"
-    if not os.path.exists(dir):
-        os.makedirs(dir)
-    with open(dir + separator + "asteroidpy.ini", "w") as f:
+    # Persist configuration at $HOME/.asteroidpy
+    home_dir = os.path.expanduser("~")
+    config_path = os.path.join(home_dir, ".asteroidpy")
+    if home_dir and not os.path.exists(home_dir):
+        os.makedirs(home_dir, exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
         config.write(f)
 
 
@@ -56,7 +54,7 @@ def initialize(config: ConfigParser) -> None:
         "east_altitude": '0',
         "nord_altitude": '0',
         "south_altitude": '0',
-        "west_altitude": '0,
+        "west_altitude": '0',
     }
     print("inizializzato")
     save_config(config)
@@ -74,22 +72,13 @@ def load_config(config: ConfigParser) -> None:
     -------
 
     """
-    dir_path = user_config_dir("AsteroidPy")
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
-    if system() == "Windows":
-        separator = "\\"
-    else:
-        separator = "/"
-    i = 0
-    for root, dirs, files in os.walk(user_config_dir("AsteroidPy")):
-        if "asteroidpy.ini" in files:
-            config.read(user_config_dir("AsteroidPy") +
-                        separator + "asteroidpy.ini")
-            break
-        else:
-            initialize(config)
-        i += 1
+    # Read configuration from $HOME/.asteroidpy if it exists; otherwise initialize
+    home_dir = os.path.expanduser("~")
+    config_path = os.path.join(home_dir, ".asteroidpy")
+    if os.path.exists(config_path):
+        config.read(config_path, encoding="utf-8")
+        return
+    initialize(config)
 
 
 def change_language(config: ConfigParser, lang: str) -> None:

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -146,7 +146,7 @@ def test_observing_target_list_scraper_parses_table(monkeypatch, sch):
     data = sch.observing_target_list_scraper("https://mpc", {"k": "v"})
 
     # Expect at least one non-empty row present
-    assert any(row for row in data), "Expected at least one parsed row"
+    assert any(data), "Expected at least one parsed row"
     assert [
         "2025 AB",
         "18.2",


### PR DESCRIPTION
…; fix tests

Switch configuration persistence from platformdirs path to $HOME/.asteroidpy to match test expectations and CLI behavior. Also fix a syntax error in default observatory settings and simplify load_config to read/write this single location. Adjust test to avoid redundant generator in assertion.

## Summary by Sourcery

Switch configuration persistence to a single ~/.asteroidpy file, correct a syntax error in default settings, restructure load/save routines, and update a test assertion.

Bug Fixes:
- Fix missing quote in default "west_altitude" observatory setting.

Enhancements:
- Persist and load configuration exclusively from ~/.asteroidpy and simplify related functions.

Tests:
- Update scheduling test to use any(data) instead of a redundant generator in the assertion.