### PR TITLE
91 suggestion code quality weve found these issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Weather: Handle unknown forecast codes gracefully (avoid KeyError)
 - Weather: Narrow exception handling when formatting forecast time (catch only TypeError/ValueError to avoid masking bugs)
 - Configuration: Avoid creating the user's home directory; write to `~/.asteroidpy` directly
+- Configuration: Use `~/.asteroidpy` for config and correct defaults; align tests
+- i18n: Clarify that checking only `base.po/.mo` may not guarantee translation availability
+- Weather/UI: Improve default wind direction display (avoid ambiguous '?')
+- Docs/Security: Add `SECURITY.md` policy
 
 ### 2025-08-11
 - types: Add and refine type hints across package and configure mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Locales: Added it, en, de, fr, es, pt and compiled `.mo`
 - Weather: Handle unknown forecast codes gracefully (avoid KeyError)
 - Weather: Narrow exception handling when formatting forecast time (catch only TypeError/ValueError to avoid masking bugs)
+- Configuration: Avoid creating the user's home directory; write to `~/.asteroidpy` directly
 
 ### 2025-08-11
 - types: Add and refine type hints across package and configure mypy

--- a/asteroidpy/configuration.py
+++ b/asteroidpy/configuration.py
@@ -23,8 +23,6 @@ def save_config(config: ConfigParser) -> None:
     # Persist configuration at $HOME/.asteroidpy
     home_dir = os.path.expanduser("~")
     config_path = os.path.join(home_dir, ".asteroidpy")
-    if home_dir and not os.path.exists(home_dir):
-        os.makedirs(home_dir, exist_ok=True)
     with open(config_path, "w", encoding="utf-8") as f:
         config.write(f)
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -18,9 +18,7 @@ def tmp_home(monkeypatch, tmp_path):
     original_expanduser = os.path.expanduser
 
     def fake_expanduser(path: str) -> str:
-        if path == "~":
-            return str(fake_home)
-        return original_expanduser(path)
+        return str(fake_home) if path == "~" else original_expanduser(path)
 
     monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
 


### PR DESCRIPTION
closes #91

## Summary by Sourcery

Standardize configuration persistence by saving to $HOME/.asteroidpy, simplify load/save logic, enforce UTF-8 encoding, and clean up related tests and a stray syntax error.

Bug Fixes:
- Fix missing closing quote in west_altitude default value.

Enhancements:
- Persist configuration at ~/.asteroidpy using os.path.expanduser and os.path.join with directory creation.
- Simplify load_config to read directly from config_path or call initialize when missing.
- Read and write config files with explicit UTF-8 encoding.

Tests:
- Streamline fake_expanduser in tmp_home fixture and simplify scheduling test assertion to any(data).