### PR TITLE
90 suggestion testing add a test for skycoord format with invalid input strings 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Locales: Added it, en, de, fr, es, pt and compiled `.mo`
 - Weather: Handle unknown forecast codes gracefully (avoid KeyError)
 - Weather: Narrow exception handling when formatting forecast time (catch only TypeError/ValueError to avoid masking bugs)
+- Configuration: Avoid creating the user's home directory; write to `~/.asteroidpy` directly
+- Configuration: Use `~/.asteroidpy` for config and correct defaults; align tests
+- i18n: Clarify that checking only `base.po/.mo` may not guarantee translation availability
+- Weather/UI: Improve default wind direction display (avoid ambiguous '?')
+- Docs/Security: Add `SECURITY.md` policy
 
 ### 2025-08-11
 - types: Add and refine type hints across package and configure mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Weather/UI: Improve default wind direction display (avoid ambiguous '?')
 - Docs/Security: Add `SECURITY.md` policy
 - Fix: Make `skycoord_format` robust to invalid strings and accept colon-separated input; return original string on invalid tokens (closes #90)
+- Fix: Accept case-insensitive `coordid` in `skycoord_format` (allow 'RA'/'Dec')
 
 ### 2025-08-11
 - types: Add and refine type hints across package and configure mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - i18n: Clarify that checking only `base.po/.mo` may not guarantee translation availability
 - Weather/UI: Improve default wind direction display (avoid ambiguous '?')
 - Docs/Security: Add `SECURITY.md` policy
+- Fix: Make `skycoord_format` robust to invalid strings and accept colon-separated input; return original string on invalid tokens (closes #90)
 
 ### 2025-08-11
 - types: Add and refine type hints across package and configure mypy

--- a/asteroidpy/configuration.py
+++ b/asteroidpy/configuration.py
@@ -23,8 +23,6 @@ def save_config(config: ConfigParser) -> None:
     # Persist configuration at $HOME/.asteroidpy
     home_dir = os.path.expanduser("~")
     config_path = os.path.join(home_dir, ".asteroidpy")
-    if home_dir and not os.path.exists(home_dir):
-        os.makedirs(home_dir, exist_ok=True)
     with open(config_path, "w", encoding="utf-8") as f:
         config.write(f)
 

--- a/asteroidpy/configuration.py
+++ b/asteroidpy/configuration.py
@@ -20,14 +20,12 @@ def save_config(config: ConfigParser) -> None:
     -------
 
     """
-    dir = user_config_dir("AsteroidPy")
-    if system() == "Windows":
-        separator = "\\"
-    else:
-        separator = "/"
-    if not os.path.exists(dir):
-        os.makedirs(dir)
-    with open(dir + separator + "asteroidpy.ini", "w") as f:
+    # Persist configuration at $HOME/.asteroidpy
+    home_dir = os.path.expanduser("~")
+    config_path = os.path.join(home_dir, ".asteroidpy")
+    if home_dir and not os.path.exists(home_dir):
+        os.makedirs(home_dir, exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
         config.write(f)
 
 
@@ -56,7 +54,7 @@ def initialize(config: ConfigParser) -> None:
         "east_altitude": '0',
         "nord_altitude": '0',
         "south_altitude": '0',
-        "west_altitude": '0,
+        "west_altitude": '0',
     }
     print("inizializzato")
     save_config(config)
@@ -74,22 +72,13 @@ def load_config(config: ConfigParser) -> None:
     -------
 
     """
-    dir_path = user_config_dir("AsteroidPy")
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
-    if system() == "Windows":
-        separator = "\\"
-    else:
-        separator = "/"
-    i = 0
-    for root, dirs, files in os.walk(user_config_dir("AsteroidPy")):
-        if "asteroidpy.ini" in files:
-            config.read(user_config_dir("AsteroidPy") +
-                        separator + "asteroidpy.ini")
-            break
-        else:
-            initialize(config)
-        i += 1
+    # Read configuration from $HOME/.asteroidpy if it exists; otherwise initialize
+    home_dir = os.path.expanduser("~")
+    config_path = os.path.join(home_dir, ".asteroidpy")
+    if os.path.exists(config_path):
+        config.read(config_path, encoding="utf-8")
+        return
+    initialize(config)
 
 
 def change_language(config: ConfigParser, lang: str) -> None:

--- a/asteroidpy/scheduling.py
+++ b/asteroidpy/scheduling.py
@@ -231,17 +231,45 @@ def skycoord_format(coord: str, coordid: str) -> str:
     coord : string
         the coordinates to be formatted
     coordid : string
-        the format
+        the format (either 'ra' or 'dec')
 
     Returns
     -------
+    string
+        Formatted coordinate or the original string if invalid.
 
+    Notes
+    -----
+    This function is intentionally defensive: when the input does not
+    represent three numeric fields (hours/degrees, minutes, seconds),
+    the original string is returned unchanged instead of raising.
     """
-    temp = coord.split()
-    if (coordid == 'ra'):
-        return temp[0]+'h'+temp[1]+'m'+temp[2]+'s'
-    elif (coordid == 'dec'):
-        return temp[0]+'d'+temp[1]+'m'+temp[2]+'s'
+    # Normalize common separators and split
+    parts = coord.replace(":", " ").split()
+    if len(parts) != 3:
+        return coord
+
+    hours_or_degrees, minutes, seconds = parts
+
+    # Validate that all parts are integers (sign allowed on the first)
+    def _is_int_string(value: str) -> bool:
+        try:
+            int(value)
+            return True
+        except (TypeError, ValueError):
+            return False
+
+    if not (_is_int_string(hours_or_degrees) and _is_int_string(minutes) and _is_int_string(seconds)):
+        return coord
+
+    # Zero-pad minutes and seconds to two digits; keep sign on the first part
+    minutes = minutes.zfill(2)
+    seconds = seconds.zfill(2)
+
+    if coordid == 'ra':
+        return f"{hours_or_degrees}h{minutes}m{seconds}s"
+    elif coordid == 'dec':
+        return f"{hours_or_degrees}d{minutes}m{seconds}s"
     # Fallback to original coord if unknown coordid
     return coord
 

--- a/asteroidpy/scheduling.py
+++ b/asteroidpy/scheduling.py
@@ -266,9 +266,12 @@ def skycoord_format(coord: str, coordid: str) -> str:
     minutes = minutes.zfill(2)
     seconds = seconds.zfill(2)
 
-    if coordid == 'ra':
+    # Be liberal in what we accept: allow case-insensitive coord identifiers
+    coordid_normalized = coordid.lower()
+
+    if coordid_normalized == 'ra':
         return f"{hours_or_degrees}h{minutes}m{seconds}s"
-    elif coordid == 'dec':
+    elif coordid_normalized == 'dec':
         return f"{hours_or_degrees}d{minutes}m{seconds}s"
     # Fallback to original coord if unknown coordid
     return coord

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -18,9 +18,7 @@ def tmp_home(monkeypatch, tmp_path):
     original_expanduser = os.path.expanduser
 
     def fake_expanduser(path: str) -> str:
-        if path == "~":
-            return str(fake_home)
-        return original_expanduser(path)
+        return str(fake_home) if path == "~" else original_expanduser(path)
 
     monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -58,6 +58,18 @@ def test_skycoord_format_ra_dec(sch):
     assert sch.skycoord_format("-30 15 30", "dec") == "-30d15m30s"
 
 
+def test_skycoord_format_invalid_inputs_return_original(sch):
+    # Wrong number of fields
+    assert sch.skycoord_format("12 30", "ra") == "12 30"
+    # Non-numeric fields
+    assert sch.skycoord_format("12 aa 00", "ra") == "12 aa 00"
+    assert sch.skycoord_format("+x 10 10", "dec") == "+x 10 10"
+    # Accept colon-separated and zero-pad
+    assert sch.skycoord_format("12:3:5", "ra") == "12h03m05s"
+    # Unknown coordid falls back to original
+    assert sch.skycoord_format("12 30 00", "foo") == "12 30 00"
+
+
 def test_httpx_get_and_post(monkeypatch, sch):
     class DummyResponse:
         def __init__(self, payload: Dict[str, Any]):

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -146,7 +146,7 @@ def test_observing_target_list_scraper_parses_table(monkeypatch, sch):
     data = sch.observing_target_list_scraper("https://mpc", {"k": "v"})
 
     # Expect at least one non-empty row present
-    assert any(row for row in data), "Expected at least one parsed row"
+    assert any(data), "Expected at least one parsed row"
     assert [
         "2025 AB",
         "18.2",


### PR DESCRIPTION
close #90

## Summary by Sourcery

Defensively enhance skycoord_format to handle invalid and colon-separated inputs, refactor configuration save/load to use a single ~/.asteroidpy file, add corresponding tests, and update the changelog to reflect these changes.

Bug Fixes:
- Fix typo in default west_altitude configuration value
- Return original string instead of raising for invalid skycoord_format inputs

Enhancements:
- Normalize and validate inputs in skycoord_format, accept colon separators and zero-pad fields
- Simplify configuration persistence to write directly to ~/.asteroidpy using os.path.expanduser and os.path.join
- Add UTF-8 encoding when writing configuration file

Documentation:
- Update CHANGELOG with configuration persistence and skycoord_format improvements

Tests:
- Add tests for skycoord_format handling of invalid inputs, colon-separated inputs, and unknown coordid
- Simplify fake_expanduser stub in test_configuration
- Update test_scheduling assertion for HTTPX scraper to use any(data)