### PR TITLE
Nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Weather: Narrow exception handling when formatting forecast time (catch only TypeError/ValueError to avoid masking bugs)
 - Configuration: Avoid creating the user's home directory; write to `~/.asteroidpy` directly
 - Configuration: Use `~/.asteroidpy` for config and correct defaults; align tests
+- Configuration: Gracefully handle unreadable or invalid `~/.asteroidpy` by falling back to initialize
+- tests: Add coverage for unreadable config file permissions scenario
 - i18n: Clarify that checking only `base.po/.mo` may not guarantee translation availability
 - Weather/UI: Improve default wind direction display (avoid ambiguous '?')
 - Docs/Security: Add `SECURITY.md` policy

--- a/asteroidpy/configuration.py
+++ b/asteroidpy/configuration.py
@@ -74,7 +74,15 @@ def load_config(config: ConfigParser) -> None:
     home_dir = os.path.expanduser("~")
     config_path = os.path.join(home_dir, ".asteroidpy")
     if os.path.exists(config_path):
-        config.read(config_path, encoding="utf-8")
+        # Attempt to read. If unreadable (permissions) or invalid/empty,
+        # fall back to initialize to ensure required sections exist.
+        try:
+            read_files = config.read(config_path, encoding="utf-8")
+        except Exception:
+            read_files = []
+
+        if not read_files or not config.sections():
+            initialize(config)
         return
     initialize(config)
 

--- a/tests/test_configuration_unreadable.py
+++ b/tests/test_configuration_unreadable.py
@@ -1,0 +1,28 @@
+import os
+import stat
+from configparser import ConfigParser
+import pytest
+
+import asteroidpy.configuration as cfg
+
+
+def test_load_config_initializes_when_file_unreadable(tmp_path, monkeypatch):
+    # Fake HOME
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(fake_home) if p == "~" else os.path.expanduser(p))
+
+    cfg_path = fake_home / ".asteroidpy"
+    cfg_path.write_text("[General]\nlang = en\n", encoding="utf-8")
+
+    # Remove read permission
+    cfg_path.chmod(stat.S_IWUSR)
+
+    config = ConfigParser()
+    cfg.load_config(config)
+
+    # After fallback to initialize, file should be recreated and readable
+    assert os.path.exists(cfg_path)
+    # The config should contain the default sections from initialize
+    assert config.has_section("General")
+    assert config.has_section("Observatory")


### PR DESCRIPTION
## Summary by Sourcery

Enhance load_config to catch errors and detect invalid reads for the user config file, falling back to initialize defaults, and add a test covering the unreadable file scenario.

Enhancements:
- Gracefully handle unreadable or invalid `~/.asteroidpy` config files by falling back to initialization

Documentation:
- Document the new fallback behavior for unreadable or invalid config files in CHANGELOG.md

Tests:
- Add test to verify fallback and re-creation of config file when permissions prevent reading