### PR TITLE
87 suggestion testing add a test for object ephemeris with an invalid stepping code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Docs/Security: Add `SECURITY.md` policy
 - Fix: Make `skycoord_format` robust to invalid strings and accept colon-separated input; return original string on invalid tokens (closes #90)
 - Fix: Accept case-insensitive `coordid` in `skycoord_format` (allow 'RA'/'Dec')
+- tests: Add coverage for `object_ephemeris` invalid stepping code; default to 1-hour on unknown code (closes #87)
 
 ### 2025-08-11
 - types: Add and refine type hints across package and configure mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Configuration: Use `~/.asteroidpy` for config and correct defaults; align tests
 - Configuration: Gracefully handle unreadable or invalid `~/.asteroidpy` by falling back to initialize
 - tests: Add coverage for unreadable config file permissions scenario
+- tests: Add coverage for corrupted/invalid config content fallback in `load_config` (closes #88)
 - i18n: Clarify that checking only `base.po/.mo` may not guarantee translation availability
 - Weather/UI: Improve default wind direction display (avoid ambiguous '?')
 - Docs/Security: Add `SECURITY.md` policy

--- a/tests/test_configuration_corrupted.py
+++ b/tests/test_configuration_corrupted.py
@@ -1,0 +1,32 @@
+import os
+from configparser import ConfigParser
+import pytest
+
+import asteroidpy.configuration as cfg
+
+
+def test_load_config_initializes_when_file_corrupted(tmp_path, monkeypatch):
+    # Fake HOME
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: str(fake_home) if p == "~" else os.path.expanduser(p),
+    )
+
+    cfg_path = fake_home / ".asteroidpy"
+    # Write invalid INI content (no section headers)
+    cfg_path.write_text("not an INI file\nkey = value\n", encoding="utf-8")
+
+    config = ConfigParser()
+    cfg.load_config(config)
+
+    # After fallback to initialize, config should have default sections
+    assert config.has_section("General")
+    assert config.has_section("Observatory")
+
+    # And the file should have been (re)written with valid INI sections
+    text = cfg_path.read_text(encoding="utf-8")
+    assert "[General]" in text
+    assert "[Observatory]" in text

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -339,3 +339,32 @@ def test_object_ephemeris_monkeypatched_mpc(monkeypatch, fresh_config, sch):
 
     t = sch.object_ephemeris(fresh_config, "Ceres", stepping="w")
     assert len(t) == 2
+
+
+def test_object_ephemeris_invalid_stepping_defaults_to_hour(monkeypatch, fresh_config, sch):
+    calls: Dict[str, Any] = {}
+
+    def fake_get_ephemeris(name: str, location: Any, step: Any, number: int):
+        calls["step"] = step
+        from astropy.table import QTable
+
+        # Single-row minimal table carrying expected columns
+        return QTable(
+            {
+                "Date": ["t1"],
+                "RA": ["1h"],
+                "Dec": ["+1d"],
+                "Elongation": [10.0],
+                "V": [18.0],
+                "Altitude": [30.0],
+                "Proper motion": [0.1],
+                "Direction": ["E"],
+            }
+        )
+
+    monkeypatch.setattr(sch.MPC, "get_ephemeris", fake_get_ephemeris)
+
+    # Use an unsupported stepping code; implementation should default to '1h'
+    t = sch.object_ephemeris(fresh_config, "Ceres", stepping="x")
+    assert len(t) == 1
+    assert calls["step"] == "1h"


### PR DESCRIPTION
closes #87

## Summary by Sourcery

Add test coverage for object_ephemeris invalid stepping code fallback to 1h and for handling corrupted configuration files, and update the changelog accordingly

Documentation:
- Document new tests for invalid stepping code fallback (closes #87) and corrupted config handling (closes #88) in CHANGELOG.md

Tests:
- Add test_object_ephemeris_invalid_stepping_defaults_to_hour to ensure unknown stepping codes default to 1h
- Add test_load_config_initializes_when_file_corrupted to ensure corrupted INI files revert to default configuration sections