### PR TITLE
85 suggestion testing add tests for malformed or missing html tables in observing target list scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Fix: Accept case-insensitive `coordid` in `skycoord_format` (allow 'RA'/'Dec')
  - Fix: Apply `min_altitude` filtering in `neocp_confirmation` and expose it via the menu (closes #86)
  - tests: Add positive-path test for NEOCP confirmation including a valid object passing all filters
+- Fix: Make `observing_target_list_scraper` robust when the MPC page has fewer than four tables or unexpected/missing headers; return an empty list when no suitable table is found (closes #85)
+- Fix: Make `observing_target_list` skip malformed rows and unparseable times defensively
+- tests: Add coverage for no-table, wrong-headers, and malformed-row cases in observing target list scraping
 
 ### 2025-08-11
 - types: Add and refine type hints across package and configure mypy


### PR DESCRIPTION
closes #85

## Summary by Sourcery

Improve robustness of target list scraping by detecting suitable HTML tables and defensively skipping malformed rows, introduce and expose a minimum altitude filter in NEOCP confirmation, and add comprehensive tests for these edge cases and positive confirmation path

New Features:
- Add minimum altitude threshold input to the neocp_confirmation menu

Bug Fixes:
- Make observing_target_list_scraper return an empty list when fewer than four tables or expected headers are missing
- Skip rows with insufficient fields or unparseable times in observing_target_list
- Apply min_altitude filtering in neocp_confirmation

Tests:
- Add tests for observing_target_list_scraper edge cases (no tables, missing headers, malformed rows)
- Add positive-path test for neocp_confirmation including a valid object passing all filters