### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/asteroidpy/configuration.py
+++ b/asteroidpy/configuration.py
@@ -223,13 +223,15 @@ def change_observer_name(config: ConfigParser, name: str) -> None:
     save_config(config)
 
 
-def print_obs_config(config: ConfigParser) -> None:
+def print_obs_config(config: ConfigParser, show_sensitive: bool = False) -> None:
     """Prints Observatory configuration parameters
 
     Parameters
     ----------
     config : Configparser
         the Configparser object with configuration option
+    show_sensitive : bool, optional
+        If True, prints sensitive observer location information. Defaults to False (redacted).
 
     Returns
     -------
@@ -240,11 +242,11 @@ def print_obs_config(config: ConfigParser) -> None:
         if config.has_option("Observatory", "place"):
             print("Località: %s" % config["Observatory"]["place"])
         if config.has_option("Observatory", "latitude"):
-            print("Latitudine: %s" % config["Observatory"]["latitude"])
+            print("Latitudine: %s" % (config["Observatory"]["latitude"] if show_sensitive else "***REDACTED***"))
         if config.has_option("Observatory", "longitude"):
-            print("Longitudine: %s" % config["Observatory"]["longitude"])
+            print("Longitudine: %s" % (config["Observatory"]["longitude"] if show_sensitive else "***REDACTED***"))
         if config.has_option("Observatory", "altitude"):
-            print("Altitudine: %s" % config["Observatory"]["altitude"])
+            print("Altitudine: %s" % (config["Observatory"]["altitude"] if show_sensitive else "***REDACTED***"))
         if config.has_option("Observatory", "observer_name"):
             print("Osservatore: %s" % config["Observatory"]["observer_name"])
         if config.has_option("Observatory", "obs_name"):


### PR DESCRIPTION
Potential fix for [https://github.com/ziriuz84/asteroidpy/security/code-scanning/1](https://github.com/ziriuz84/asteroidpy/security/code-scanning/1)

The best way to fix this is to avoid printing sensitive information unless the user has explicitly requested it, or to redact sensitive data before outputting. Since the `print_obs_config` function outputs several fields, we should redact (mask) sensitive fields such as "latitude" and "longitude". Instead of printing their full values, replace the value with a redacted string (e.g., "***REDACTED***"). If showing these values may sometimes be appropriate, add an optional parameter to allow their inclusion, defaulting to redaction.

**In this concrete situation:**  
- Edit the lines in `print_obs_config` that print `latitude` and `longitude` (and possibly `altitude` if deemed sensitive).
- Replace the value with `***REDACTED***`, or, if appropriate, add a flag `show_sensitive=False` to the function signature, and only print the true value if this flag is set to `True`.
- Only modify the given code snippets within the shown file.
- No new dependencies or imports are needed unless a redaction utility or logging module is preferred, but for now, simple string redaction is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Secure print_obs_config by redacting sensitive observer location fields by default and adding an optional flag to reveal them.

Bug Fixes:
- Prevent clear-text logging of latitude, longitude, and altitude by redacting their values.

Enhancements:
- Introduce show_sensitive parameter to print_obs_config to control redaction of sensitive data.

Documentation:
- Update print_obs_config docstring to document the new show_sensitive option.